### PR TITLE
fix: Upgrade webpack-cli version

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
 		"vue-template-compiler": "^2.5.17",
 		"webpack": "^4.17.1",
 		"webpack-bundle-analyzer": "^2.13.1",
-		"webpack-cli": "^2.1.5",
+		"webpack-cli": "^3.1.2",
 		"webpack-dev-server": "^3.1.6",
 		"webpack-merge": "^4.1.4",
 		"workbox-webpack-plugin": "^3.4.1"


### PR DESCRIPTION
When I built the project locally, I got this error:

```
$ webpack-dev-server --inline --progress --config build/webpack.dev.conf.js
/home/webd/workspace/Web/node_modules/webpack-cli/bin/config-yargs.js:89
				describe: optionsSchema.definitions.output.properties.path.description,
				                                           ^

TypeError: Cannot read property 'properties' of undefined
    at module.exports (/home/webd/workspace/Web/node_modules/webpack-cli/bin/config-yargs.js:89:48)
    at Object.<anonymous> (/home/webd/workspace/Web/node_modules/webpack-dev-server/bin/webpack-dev-server.js:84:40)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:742:12)
    at startup (internal/bootstrap/node.js:279:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:752:3)
```
I upgrade the version of webpack-cli from ``2.1.5`` to ``3.1.2`` and the error seams to be fixed.